### PR TITLE
Add checks for STRICT compatibility mode and remote_store_enabled indices

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreMigrationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreMigrationAllocationIT.java
@@ -8,7 +8,9 @@
 
 package org.opensearch.remotestore;
 import org.opensearch.action.admin.cluster.allocation.ClusterAllocationExplanation;
+import org.opensearch.action.admin.cluster.reroute.ClusterRerouteResponse;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -19,17 +21,24 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.opensearch.cluster.routing.allocation.MoveDecision;
 import org.opensearch.cluster.routing.allocation.NodeAllocationResult;
+import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.indices.settings.InternalOrPrivateSettingsPlugin;
+import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
+import static org.opensearch.cluster.metadata.IndexMetadata.*;
 import static org.opensearch.node.remotestore.RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING;
 import static org.opensearch.node.remotestore.RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING;
 import static org.opensearch.remotestore.RemoteStoreBaseIntegTestCase.remoteStoreClusterSettings;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -84,6 +93,16 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL, "true").build();
     }
 
+    @Override
+    protected boolean forbidPrivateIndexSettings() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(InternalOrPrivateSettingsPlugin.class);
+    }
+
 
     // tests for primary shard copy allocation with REMOTE_STORE direction
 
@@ -107,7 +126,10 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         }
 
         logger.info(" --> verify expected decision for allocating a new primary shard on a non-remote node");
-        prepareIndex(1, 0);
+        boolean isRemoteStoreEnabledIndex = randomBoolean();
+        prepareIndex(1, 0, getRemoteStoreEnabledIndexSettingsBuilder(isRemoteStoreEnabledIndex));
+        assertEquals((isRemoteStoreEnabledIndex ? "true" : null), client.admin().cluster().prepareState().execute()
+            .actionGet().getState().getMetadata().index(TEST_INDEX).getSettings().get(SETTING_REMOTE_STORE_ENABLED));
 
         Decision decision = getDecisionForTargetNode(nonRemoteNode, true, false, false);
         assertEquals(Decision.Type.NO, decision.type());
@@ -115,6 +137,9 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         if (!isMixedMode) {
             //  strict mode
             reason = reason.concat(" because target node cannot be non-remote in STRICT mode");
+        }
+        else if (isRemoteStoreEnabledIndex) {
+            reason = reason.concat(" for remote_store_enabled index");
         }
         assertEquals(reason, decision.getExplanation());
 
@@ -161,7 +186,11 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         }
 
         logger.info(" --> verify expected decision for allocating a new primary shard on a remote node");
-        prepareIndex(1, 0);
+        boolean isRemoteStoreEnabledIndex = randomBoolean();
+        prepareIndex(1, 0, getRemoteStoreEnabledIndexSettingsBuilder(isRemoteStoreEnabledIndex));
+        assertEquals((isRemoteStoreEnabledIndex ? "true" : null), client.admin().cluster().prepareState().execute()
+            .actionGet().getState().getMetadata().index(TEST_INDEX).getSettings().get(SETTING_REMOTE_STORE_ENABLED));
+
         Decision decision = getDecisionForTargetNode(remoteNode, true, true, false);
         assertEquals(Decision.Type.YES, decision.type());
         assertEquals("[REMOTE_STORE migration_direction]: primary shard copy can be allocated to a remote_store node", decision.getExplanation());
@@ -212,7 +241,7 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate(TEST_INDEX)
             .setSettings(
-                Settings.builder()
+                getRemoteStoreEnabledIndexSettingsBuilder(false)
                     .put("index.number_of_shards", 1)
                     .put("index.number_of_replicas", 1)
                     .put("index.routing.allocation.include._name", nonRemoteNodeName)
@@ -233,6 +262,13 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
 
         logger.info(" --> set remote_store direction");
         setDirection(REMOTE_STORE_DIRECTION);
+
+        boolean isRemoteStoreEnabledIndex = randomBoolean();
+        if (isRemoteStoreEnabledIndex) {
+            setRemoteStoreEnabledIndex();
+        }
+        assertEquals((isRemoteStoreEnabledIndex ? "true" : null), client.admin().cluster().prepareState().execute()
+            .actionGet().getState().getMetadata().index(TEST_INDEX).getSettings().get(SETTING_REMOTE_STORE_ENABLED));
 
         boolean isStrictMode = randomBoolean();
         if (isStrictMode) {
@@ -287,7 +323,7 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate(TEST_INDEX)
             .setSettings(
-                Settings.builder()
+                getRemoteStoreEnabledIndexSettingsBuilder(false)
                     .put("index.number_of_shards", 1)
                     .put("index.number_of_replicas", 1)
                     .put("index.routing.allocation.include._name", remoteNodeName1)
@@ -308,6 +344,13 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
 
         logger.info(" --> set remote_store direction");
         setDirection(REMOTE_STORE_DIRECTION);
+
+        boolean isRemoteStoreEnabledIndex = randomBoolean();
+        if (isRemoteStoreEnabledIndex) {
+            setRemoteStoreEnabledIndex();
+        }
+        assertEquals((isRemoteStoreEnabledIndex ? "true" : null), client.admin().cluster().prepareState().execute()
+            .actionGet().getState().getMetadata().index(TEST_INDEX).getSettings().get(SETTING_REMOTE_STORE_ENABLED));
 
         boolean isStrictMode = randomBoolean();
         if (isStrictMode) {
@@ -359,7 +402,7 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate(TEST_INDEX)
             .setSettings(
-                Settings.builder()
+                getRemoteStoreEnabledIndexSettingsBuilder(false)
                     .put("index.number_of_shards", 1)
                     .put("index.number_of_replicas", 1)
                     .put("index.routing.allocation.include._name", nonRemoteNodeName1)
@@ -383,6 +426,13 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         logger.info(" --> set remote_store direction");
         setDirection(REMOTE_STORE_DIRECTION);
 
+        boolean isRemoteStoreEnabledIndex = randomBoolean();
+        if (isRemoteStoreEnabledIndex) {
+            setRemoteStoreEnabledIndex();
+        }
+        assertEquals((isRemoteStoreEnabledIndex ? "true" : null), client.admin().cluster().prepareState().execute()
+            .actionGet().getState().getMetadata().index(TEST_INDEX).getSettings().get(SETTING_REMOTE_STORE_ENABLED));
+
         boolean isMixedMode = randomBoolean();
         if (isMixedMode) {
             setClusterMode(MIXED_MODE);
@@ -396,6 +446,10 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         if (!isMixedMode) {
             type = Decision.Type.NO;
             reason = "[REMOTE_STORE migration_direction]: replica shard copy can not be allocated to a non_remote_store node because target node cannot be non-remote in STRICT mode";
+        }
+        else if (isRemoteStoreEnabledIndex) {
+            type = Decision.Type.NO;
+            reason = "[REMOTE_STORE migration_direction]: replica shard copy can not be allocated to a non_remote_store node for remote_store_enabled index";
         }
         assertEquals(type, decision.type());
         assertEquals(reason, decision.getExplanation());
@@ -412,7 +466,7 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
             .execute()
             .actionGet();
 
-        if (!isMixedMode) {
+        if (!isMixedMode || isRemoteStoreEnabledIndex) {
             ensureYellowAndNoInitializingShards(TEST_INDEX);
 
             logger.info(" --> verify non-allocation of replica shard");
@@ -453,7 +507,7 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate(TEST_INDEX)
             .setSettings(
-                Settings.builder()
+                getRemoteStoreEnabledIndexSettingsBuilder(false)
                     .put("index.number_of_shards", 1)
                     .put("index.number_of_replicas", 1)
                     .put("index.routing.allocation.include._name", remoteNodeName)
@@ -475,6 +529,13 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         logger.info(" --> set remote_store direction");
         setDirection(REMOTE_STORE_DIRECTION);
 
+        boolean isRemoteStoreEnabledIndex = randomBoolean();
+        if (isRemoteStoreEnabledIndex) {
+            setRemoteStoreEnabledIndex();
+        }
+        assertEquals((isRemoteStoreEnabledIndex ? "true" : null), client.admin().cluster().prepareState().execute()
+            .actionGet().getState().getMetadata().index(TEST_INDEX).getSettings().get(SETTING_REMOTE_STORE_ENABLED));
+
         boolean isStrictMode = randomBoolean();
         if (isStrictMode) {
             setClusterMode(STRICT_MODE);
@@ -489,6 +550,10 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         if (isStrictMode) {
             type = Decision.Type.NO;
             reason = "[REMOTE_STORE migration_direction]: replica shard copy can not be allocated to a non_remote_store node because target node cannot be non-remote in STRICT mode";
+        }
+        else if (isRemoteStoreEnabledIndex) {
+            type = Decision.Type.NO;
+            reason = "[REMOTE_STORE migration_direction]: replica shard copy can not be allocated to a non_remote_store node for remote_store_enabled index";
         }
         assertEquals(type, decision.type());
         assertEquals(reason, decision.getExplanation());
@@ -505,7 +570,7 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
             .execute()
             .actionGet();
 
-        if (isStrictMode) {
+        if (isStrictMode || isRemoteStoreEnabledIndex) {
             ensureYellowAndNoInitializingShards(TEST_INDEX);
 
             logger.info(" --> verify non-allocation of replica shard");
@@ -521,6 +586,171 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
             replicaShardRouting = routingTable.index(TEST_INDEX).shard(0).replicaShards().get(0);
             assertAllocation(replicaShardRouting, nonRemoteNode);
         }
+    }
+
+
+    // remote store enabled index no decisions
+
+    public void testReturnNoForRelocationOfRemoteStoreEnabledIndexFromNonRemoteNode () {
+        logger.info(" --> initialize cluster");
+        initializeCluster();
+
+        logger.info(" --> add nodes");
+        setClusterMode(MIXED_MODE);
+        addRemote = false;
+        String nonRemoteNodeName = internalCluster().startNode();
+        addRemote = true;
+        String remoteNodeName = internalCluster().startNode();
+        internalCluster().validateClusterFormed();
+        DiscoveryNode nonRemoteNode = assertNodeInCluster(nonRemoteNodeName);
+        DiscoveryNode remoteNode = assertNodeInCluster(remoteNodeName);
+        assertFalse(nonRemoteNode.isRemoteStoreNode());
+        assertTrue(remoteNode.isRemoteStoreNode());
+
+        logger.info(" --> allocate primary on nonRemoteNode");
+        Settings.Builder remoteStoreEnabledIndexSettingsBuilder = getRemoteStoreEnabledIndexSettingsBuilder(false);
+        client.admin()
+            .indices()
+            .prepareCreate(TEST_INDEX)
+            .setSettings(
+                remoteStoreEnabledIndexSettingsBuilder
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.routing.allocation.include._name", nonRemoteNodeName)
+                    .put("index.routing.allocation.exclude._name", allNodesExcept(nonRemoteNodeName))
+            )
+            .execute()
+            .actionGet();
+
+        ensureGreen(TEST_INDEX);
+
+        logger.info(" --> verify allocation of primary shard");
+        RoutingTable routingTable = client.admin().cluster().prepareState().execute().actionGet().getState().getRoutingTable();
+        ShardRouting primaryShardRouting = routingTable.index(TEST_INDEX).shard(0).primaryShard();
+        assertAllocation(primaryShardRouting, nonRemoteNode);
+
+        logger.info(" --> set remote_store_enabled index");
+        setRemoteStoreEnabledIndex();
+        setDirection(REMOTE_STORE_DIRECTION);
+
+        logger.info(" --> verify expected decision for relocating the primary shard");
+        prepareDecisions();
+        Decision decision = getDecisionForTargetNode(remoteNode, true, false, true);
+        assertEquals(Decision.Type.NO, decision.type());
+        String reason = "[REMOTE_STORE migration_direction]: primary shard copy can not be relocated to a remote_store node because remote_store_enabled index found on a non remote node";
+        assertEquals(reason, decision.getExplanation());
+
+        logger.info(" --> attempt relocation of primary shard");
+        ClusterRerouteResponse rerouteResponse = relocateShard(nonRemoteNodeName, remoteNodeName);
+        ensureYellowAndNoInitializingShards(TEST_INDEX);
+
+        logger.info(" --> verify non-relocation of primary shard");
+        routingTable = client.admin().cluster().prepareState().execute().actionGet().getState().getRoutingTable();
+        primaryShardRouting = routingTable.index(TEST_INDEX).shard(0).primaryShard();
+        assertNonRelocation(primaryShardRouting, rerouteResponse, nonRemoteNode, remoteNode, reason);
+    }
+
+    public void testDontAllocateToNonRemoteNodeForRemoteStoreEnabledIndex () {
+        logger.info(" --> initialize cluster");
+        initializeCluster();
+
+        logger.info(" --> add non-remote node");
+        addRemote = false;
+        String nonRemoteNodeName = internalCluster().startNode();
+        internalCluster().validateClusterFormed();
+        DiscoveryNode nonRemoteNode = assertNodeInCluster(nonRemoteNodeName);
+        assertFalse(nonRemoteNode.isRemoteStoreNode());
+
+        logger.info(" --> set none direction");
+        setDirection(NONE_DIRECTION);
+        setClusterMode(MIXED_MODE);
+
+        logger.info(" --> verify expected decision for allocating a new primary shard on a non-remote node");
+        prepareIndex(1, 0, getRemoteStoreEnabledIndexSettingsBuilder(true));
+        assertEquals("true", client.admin().cluster().prepareState().execute()
+            .actionGet().getState().getMetadata().index(TEST_INDEX).getSettings().get(SETTING_REMOTE_STORE_ENABLED));
+
+        Decision decision = getDecisionForTargetNode(nonRemoteNode, true, false, false);
+        assertEquals(Decision.Type.NO, decision.type());
+        assertEquals("[NONE migration_direction]: primary shard copy can not be allocated to a non_remote_store/docrep node for remote_store_enabled index", decision.getExplanation());
+
+        logger.info(" --> attempt allocation");
+        client.admin()
+            .indices()
+            .prepareUpdateSettings(TEST_INDEX)
+            .setSettings(
+                Settings.builder()
+                    .put("index.routing.allocation.include._name", nonRemoteNodeName)
+                    .put("index.routing.allocation.exclude._name", allNodesExcept(nonRemoteNodeName))
+            )
+            .execute()
+            .actionGet();
+
+        ensureRed(TEST_INDEX);
+
+        logger.info(" --> verify non-allocation of primary shard");
+        RoutingTable routingTable = client.admin().cluster().prepareState().execute().actionGet().getState().getRoutingTable();
+        ShardRouting primaryShardRouting = routingTable.index(TEST_INDEX).shard(0).primaryShard();
+        assertNonAllocation(primaryShardRouting);
+    }
+
+    public void testDontRelocateToNonRemoteNodeForRemoteStoreEnabledIndex () {
+        logger.info(" --> initialize cluster");
+        initializeCluster();
+
+        logger.info(" --> add nodes");
+        setClusterMode(MIXED_MODE);
+        addRemote = false;
+        String nonRemoteNodeName = internalCluster().startNode();
+        addRemote = true;
+        String remoteNodeName = internalCluster().startNode();
+        internalCluster().validateClusterFormed();
+        DiscoveryNode nonRemoteNode = assertNodeInCluster(nonRemoteNodeName);
+        DiscoveryNode remoteNode = assertNodeInCluster(remoteNodeName);
+        assertFalse(nonRemoteNode.isRemoteStoreNode());
+        assertTrue(remoteNode.isRemoteStoreNode());
+
+        logger.info(" --> allocate primary on remoteNode");
+        Settings.Builder remoteStoreEnabledIndexSettingsBuilder = getRemoteStoreEnabledIndexSettingsBuilder(false);
+        client.admin()
+            .indices()
+            .prepareCreate(TEST_INDEX)
+            .setSettings(
+                remoteStoreEnabledIndexSettingsBuilder
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.routing.allocation.include._name", remoteNodeName)
+                    .put("index.routing.allocation.exclude._name", allNodesExcept(remoteNodeName))
+            )
+            .execute()
+            .actionGet();
+
+        ensureGreen(TEST_INDEX);
+
+        logger.info(" --> verify allocation of primary shard");
+        RoutingTable routingTable = client.admin().cluster().prepareState().execute().actionGet().getState().getRoutingTable();
+        ShardRouting primaryShardRouting = routingTable.index(TEST_INDEX).shard(0).primaryShard();
+        assertAllocation(primaryShardRouting, remoteNode);
+
+        logger.info(" --> set remote_store_enabled index");
+        setRemoteStoreEnabledIndex();
+        setDirection(NONE_DIRECTION);
+
+        logger.info(" --> verify expected decision for relocating the primary shard");
+        prepareDecisions();
+        Decision decision = getDecisionForTargetNode(nonRemoteNode, true, false, true);
+        assertEquals(Decision.Type.NO, decision.type());
+        String reason = "[NONE migration_direction]: primary shard copy can not be relocated to a non_remote_store/docrep node for remote_store_enabled index";
+        assertEquals(reason, decision.getExplanation());
+
+        logger.info(" --> attempt relocation of primary shard");
+        ClusterRerouteResponse rerouteResponse = relocateShard(remoteNodeName, nonRemoteNodeName);
+        ensureYellowAndNoInitializingShards(TEST_INDEX);
+
+        logger.info(" --> verify non-relocation of primary shard");
+        routingTable = client.admin().cluster().prepareState().execute().actionGet().getState().getRoutingTable();
+        primaryShardRouting = routingTable.index(TEST_INDEX).shard(0).primaryShard();
+        assertNonRelocation(primaryShardRouting, rerouteResponse, remoteNode, nonRemoteNode, reason);
     }
 
 
@@ -612,12 +842,12 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
     }
 
     // create a new test index
-    private void prepareIndex (int shardCount, int replicaCount) {
+    private void prepareIndex (int shardCount, int replicaCount, Settings.Builder customSettingsBuilder) {
         client.admin()
             .indices()
             .prepareCreate(TEST_INDEX)
             .setSettings(
-                Settings.builder()
+                customSettingsBuilder
                     .put("index.number_of_shards", shardCount)
                     .put("index.number_of_replicas", replicaCount)
                     .put("index.routing.allocation.exclude._name", allNodesExcept(null))
@@ -639,6 +869,35 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
             .actionGet();
     }
 
+    // attempt relocating the shard copy at currentNode to targetNode
+    private ClusterRerouteResponse relocateShard (String currentNodeName, String targetNodeName) {
+        client.admin()
+            .indices()
+            .prepareUpdateSettings(TEST_INDEX)
+            .setSettings(
+                Settings.builder()
+                    .put("index.routing.allocation.enable", "none")
+                    .put("index.routing.allocation.include._name", targetNodeName)
+                    .put("index.routing.allocation.exclude._name", allNodesExcept(targetNodeName))
+            )
+            .execute()
+            .actionGet();
+
+        ensureGreen(TEST_INDEX);
+
+        ClusterRerouteResponse rerouteResponse = client.admin()
+            .cluster()
+            .prepareReroute()
+            .setExplain(true)
+            .add(new MoveAllocationCommand(TEST_INDEX, 0, currentNodeName, targetNodeName))
+            .execute()
+            .actionGet();
+
+        ensureGreen(TEST_INDEX);
+
+        return rerouteResponse;
+    }
+
     // verify that shard does not exist at targetNode
     private void assertNonAllocation (ShardRouting shardRouting) {
         assertFalse(shardRouting.active());
@@ -651,6 +910,56 @@ public class RemoteStoreMigrationAllocationIT extends OpenSearchIntegTestCase {
         assertTrue(shardRouting.active());
         assertNotNull(shardRouting.currentNodeId());
         assertEquals(shardRouting.currentNodeId(), targetNode.getId());
+    }
+
+    // verify that shard did not get relocated to the targetNode
+    private void assertNonRelocation (ShardRouting shardRouting, ClusterRerouteResponse rerouteResponse, DiscoveryNode currentNode, DiscoveryNode targetNode, String reason) {
+        Decision.Type decisionType = rerouteResponse.getExplanations().explanations().get(0).decisions().type();
+        List<Decision> relocationDecisions = rerouteResponse.getExplanations().explanations().get(0).decisions().getDecisions();
+        for (Decision dec: relocationDecisions) {
+            if (dec.type().equals(Decision.Type.NO)) {
+                // only one NO decision
+                assertEquals(reason, dec.getExplanation());
+            }
+        }
+        ShardRouting expectedShardRouting = rerouteResponse.getState().getRoutingTable().index(TEST_INDEX).shard(0).shards()
+            .stream().filter(sr -> sr.allocationId().equals(shardRouting.allocationId())).findFirst().orElse(null);
+        assertNotNull(expectedShardRouting);
+        assertEquals(Decision.Type.NO, decisionType);
+        assertNotNull(expectedShardRouting.currentNodeId());
+        assertEquals(currentNode.getId(), expectedShardRouting.currentNodeId());
+        assertNotEquals(targetNode.getId(), expectedShardRouting.currentNodeId());
+    }
+
+    // index settings builder for remote store enabled index
+    private Settings.Builder getRemoteStoreEnabledIndexSettingsBuilder (boolean isRemoteStoreEnabledIndex) {
+        Settings.Builder builder = Settings.builder()
+            .put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
+        if (isRemoteStoreEnabledIndex) {
+            builder
+                .put(SETTING_REMOTE_SEGMENT_STORE_REPOSITORY, REPOSITORY_NAME)
+                .put(SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, REPOSITORY_2_NAME)
+                .put(SETTING_REMOTE_STORE_ENABLED, true);
+        }
+        return builder;
+    }
+
+    // to update index settings post intialization
+    private void updatePrivateOrInternalIndexSetting (String settingKey, String value) {
+        client().execute(
+            InternalOrPrivateSettingsPlugin.UpdateInternalOrPrivateAction.INSTANCE,
+            new InternalOrPrivateSettingsPlugin.UpdateInternalOrPrivateAction.Request(TEST_INDEX, settingKey, value)
+        ).actionGet();
+        final GetSettingsResponse responseAfterUpdate = client().admin().indices().prepareGetSettings(TEST_INDEX).get();
+        assertEquals(value, responseAfterUpdate.getSetting(TEST_INDEX, settingKey));
+        assertEquals(value, client.admin().indices().prepareGetSettings(TEST_INDEX).get().getSetting(TEST_INDEX, settingKey));
+    }
+
+    // to set index as remote_store_enabled post its intialization
+    public void setRemoteStoreEnabledIndex () {
+        updatePrivateOrInternalIndexSetting(SETTING_REMOTE_STORE_ENABLED, "true");
+        updatePrivateOrInternalIndexSetting(SETTING_REMOTE_SEGMENT_STORE_REPOSITORY, REPOSITORY_NAME);
+        updatePrivateOrInternalIndexSetting(SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, REPOSITORY_2_NAME);
     }
 
 }


### PR DESCRIPTION
### Description
An allocation decider to oversee shard allocation or relocation to facilitate remote-store migration:
* For STRICT compatibility mode, the migration direction has to be same as type of target node
* For remote_store_enabled indices, relocation or allocation can only be towards a remote node

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
